### PR TITLE
Update Gems to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    acme-client (0.5.0)
+    acme-client (0.5.1)
       faraday (~> 0.9, >= 0.9.1)
-    activesupport (5.0.1)
+    activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     backports (3.6.8)
-    bindata (2.3.4)
-    concurrent-ruby (1.0.4)
-    domain_name (0.5.20161129)
+    bindata (2.3.5)
+    concurrent-ruby (1.0.5)
+    domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    i18n (0.7.0)
-    json-jwt (1.7.0)
+    i18n (0.8.1)
+    json-jwt (1.7.1)
       activesupport
       bindata
       multi_json (>= 1.3)
@@ -31,8 +31,8 @@ GEM
     minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    psych (2.2.2)
-    puma (3.6.2)
+    psych (2.2.4)
+    puma (3.7.1)
     rack (1.6.5)
     rack-attack (4.3.1)
       rack
@@ -41,7 +41,7 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     securecompare (1.0.0)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
@@ -52,8 +52,8 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    thread_safe (0.3.5)
-    tilt (2.0.5)
+    thread_safe (0.3.6)
+    tilt (2.0.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -79,4 +79,4 @@ DEPENDENCIES
   thread_safe
 
 BUNDLED WITH
-   1.10.6
+   1.14.6


### PR DESCRIPTION
activesupport 5.0.2 required to get rid of ruby warnings:

```
../ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:51: warning: constant ::Fixnum is deprecated
../ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:52: warning: constant ::Bignum is deprecated
../ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/core_ext/numeric/conversions.rb:138: warning: constant ::Fixnum is deprecated
```

bug: https://bugs.ruby-lang.org/issues/12739
commit: https://github.com/rails/rails/commit/cb0452e9a50e97f8ab2100f6226fbdd47a970a34#diff-3bce0a811b46c709db71dbaccd9e21b1

sinatra 1.4.8 required to get rid of ruby warnings:

```
../ruby/2.4.0/gems/sinatra-1.4.7/lib/sinatra/base.rb:1226: warning: constant ::Fixnum is deprecated
```

fixed by: https://github.com/sinatra/sinatra/commit/492628c1529a6ef570087ef714604a136494ebe0

backports (dependency of sinatra-contrib) still shows warnings: https://github.com/marcandre/backports/issues/104

```
../ruby/2.4.0/gems/backports-3.6.8/lib/backports/1.8.7/fixnum/div.rb:1: warning: constant ::Fixnum is deprecated
../ruby/2.4.0/gems/backports-3.6.8/lib/backports/1.8.7/fixnum/fdiv.rb:1: warning: constant ::Fixnum is deprecated
../ruby/2.4.0/gems/backports-3.6.8/lib/backports/2.1.0/bignum/bit_length.rb:1: warning: constant ::Bignum is deprecated
../ruby/2.4.0/gems/backports-3.6.8/lib/backports/2.1.0/fixnum/bit_length.rb:1: warning: constant ::Fixnum is deprecated
```